### PR TITLE
add LiquidTag to render person

### DIFF
--- a/_assets/css/main.scss
+++ b/_assets/css/main.scss
@@ -100,6 +100,14 @@ html {
       max-height: 7.5rem;
     }
 
+    .person.given-name {
+    }
+    .person.sur-name {
+      font-weight: bold;
+    }
+    .person-affiliation {
+    }
+
     .project-preparation-bg {
       background-color: lighten($brand-info, 15%);
     }

--- a/_includes/asides/project_meta.html
+++ b/_includes/asides/project_meta.html
@@ -38,18 +38,16 @@
         <label class="col-sm-4">Members</label>
         <div class="col-sm-8">
           {% if page.head %}
-            {% assign head = site.data.people[page.head] %}
             <span class="clearfix">
-              {{ head.given_name }} <strong>{{ head.sur_name }}</strong>{% if head.affiliation %} (<em>{{ site.data.orgs[head.affiliation].abbr }}</em>){% endif %}
+              {% person {{ page.head }} %}
               <span class="pull-right">
                 <a title="Project Head"><i class="fa fa-graduation-cap fa-fw"></i></a>
               </span>
             </span>
           {% endif %}
           {% for member_id in page.members %}
-            {% assign member = site.data.people[member_id] %}
             <span class="clearfix">
-              {{ member.given_name }} <strong>{{ member.sur_name }}</strong>{% if member.affiliation %} (<em>{{ site.data.orgs[member.affiliation].abbr }}</em>){% endif %}
+              {% person {{ member_id }} %}
             </span>
           {% endfor %}
         </div>

--- a/_plugins/person_tag.rb
+++ b/_plugins/person_tag.rb
@@ -1,0 +1,90 @@
+module Jekyll
+  module Tags
+    class RenderPersonTagError < StandardError
+      def initialize(msg)
+        super(msg)
+      end
+    end
+
+    class RenderPersonTag < Liquid::Tag
+      def initialize(tag_name, markup, tokens)
+        super
+        @person_id = markup.strip
+        @person = nil
+        @people
+        @affiliations = nil
+      end
+
+      def get_person(context)
+        @people = context.registers[:site].data['people']
+
+        if @people.has_key?(@person_id)
+          @person = @people[@person_id]
+        elsif @people.has_key?(Liquid::Template.parse(@person_id).render(context))
+          @person = @people[Liquid::Template.parse(@person_id).render(context)]
+        else
+          raise RenderPersonTagError.new \
+            "PersonID '#{@person_id}' not found. Typo? Otherwise add it to _data/people.yml."
+        end
+
+      end
+
+      def get_affiliations(context)
+        unless @person.has_key?('affiliation')
+          raise RenderPersonTagError.new "PersonID '#{@person_id}' has no 'affiliation' defined."
+        end
+
+        affies = context.registers[:site].data['orgs']
+
+        if @person['affiliation'].is_a?(String)
+          person_affies = [@person['affiliation']]
+        else
+          person_affies = @person['affiliation']
+        end
+
+        @affiliations = []
+        for affi in person_affies
+          unless affies.has_key?(affi)
+            raise RenderPersonTagError.new \
+              "AffiliationID '#{affi}' not found. Type? Otherwise add it to _data/orgs.yml."
+          end
+
+          @affiliations << affies[affi]
+        end
+      end
+
+      def construct_name(context)
+        get_person(context)
+
+        unless @person.has_key?('sur_name')
+          raise RenderPersonTagError.new "PersonID '#{@person_id}' has no 'sur_name' defined."
+        end
+        unless @person.has_key?('given_name')
+          raise RenderPersonTagError.new "PersonID '#{@person_id}' has no 'given_name' defined."
+        end
+
+        given_name = @person['given_name']
+        sur_name = @person['sur_name']
+
+        "<span class=\"person given-name\">#{given_name}</span> <span class=\"person sur-name\">#{sur_name}</span>"
+      end
+
+      def construct_affiliation(context)
+        get_affiliations(context)
+
+        affies = []
+        for affi in @affiliations
+          affies << "<abbr class=\"person affiliation\" title=\"#{affi['title']}\">#{affi['abbr']}</abbr>"
+        end
+
+        affies.join(', ')
+      end
+
+      def render(context)
+        "#{construct_name(context)} (#{construct_affiliation(context)})"
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('person', Jekyll::Tags::RenderPersonTag)

--- a/_projects/fmm_project.md
+++ b/_projects/fmm_project.md
@@ -52,9 +52,9 @@ none yet.
 Since December 2014:
 
 {:.table.table-bordered.table-hover.table-sm}
-| Pavan Balaji (ANL)   | 0.1 PM |
-| Ivo Kabadshow, (JSC) | 0.1 PM |
-| David Haensel, (JSC) | 1 PM   |
+| {% person balaji_p %} | 0.1 PM |
+| {% person kabadshow_i %} | 0.1 PM |
+| {% person haensel_d %} | 1 PM   |
 
 The efforts are likely to increase, once the code base includes a near-complete parallelization layer.
 

--- a/_templates/project_page
+++ b/_templates/project_page
@@ -115,11 +115,11 @@ Since December 2014:
 
 Put it in the following form, each person on its own line
 
-| PERSON | X.Y PM |
+| {% person PERSON_ID %} | X.Y PM |
 
 e.g.:
 
-| Ivo Kabadshow | 0.1 PM |
+| {% person kabadshow_i %} | 0.1 PM |
 
 Above the very first person put the following:
 

--- a/projects/index.html
+++ b/projects/index.html
@@ -24,19 +24,13 @@ subnavbar: Projects
           </h4>
           <ul class="card-text list-inline members">
           {% if project.head %}
-          {% assign head = site.data.people[project.head] %}
             <li class="list-inline-item">
-              {{ head.given_name }}
-              {{ head.sur_name }}
-              ({{ site.data.orgs[head.affiliation].abbr }}){% if project.members %},{% endif %}
+              {% person {{ project.head }} %}
             </li>
           {% endif %}
           {% for member_id in project.members %}
-            {% assign member = site.data.people[member_id] %}
             <li class="list-inline-item">
-              {{ member.given_name }}
-              {{ member.sur_name }}
-              ({{ site.data.orgs[member.affiliation].abbr }}){% unless forloop.last %},{% endunless %}
+              {% person {{ member_id }} %}
             </li>
           {% endfor %}
           </ul>


### PR DESCRIPTION
Using the new LiquidTag 'person' will render the person's name and
affiliation:

```
{% person cappello_f %}
```

will result in

```
Franck Cappello (ANL)
```

Trying to render a person, who do not exists in _data/people.yml will
result in a Liquid error and aborting the build.
