### PR TITLE
remove education and prepare summer school

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,7 @@ assets:
     automatic_img_alt: false
 
 collections:
-  summer_school:
+  education:
     output: true
   events_upcoming:
     output: true

--- a/_config.yml
+++ b/_config.yml
@@ -67,8 +67,6 @@ assets:
     automatic_img_alt: false
 
 collections:
-  education:
-    output: true
   events_upcoming:
     output: true
   events_past:

--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,7 @@ assets:
     automatic_img_alt: false
 
 collections:
-  education:
+  summer_school:
     output: true
   events_upcoming:
     output: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,6 +27,11 @@
               <a class="nav-link{% if page.navbar == 'Events' %} active{% endif %}" href="{{ site.baseurl }}/events/index.html">Events</a>
             </li>
             {% include navs/research.html %}
+{% comment %}
+            <li class="nav-item">
+              <a class="nav-link{% if page.navbar == 'SummerSchool' %} active{% endif %}" href="{{ site.baseurl }}/summer_school/index.html">Summer School</a>
+            </li>
+{% endcomment %}
             <li class="nav-item">
               <a class="nav-link{% if page.navbar == 'References' %} active{% endif %}" href="{{ site.baseurl }}/references/index.html">References</a>
             </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,11 +27,6 @@
               <a class="nav-link{% if page.navbar == 'Events' %} active{% endif %}" href="{{ site.baseurl }}/events/index.html">Events</a>
             </li>
             {% include navs/research.html %}
-{% comment %}
-            <li class="nav-item">
-              <a class="nav-link{% if page.navbar == 'SummerSchool' %} active{% endif %}" href="{{ site.baseurl }}/summer_school/index.html">Summer School</a>
-            </li>
-{% endcomment %}
             <li class="nav-item">
               <a class="nav-link{% if page.navbar == 'References' %} active{% endif %}" href="{{ site.baseurl }}/references/index.html">References</a>
             </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,9 +28,6 @@
             </li>
             {% include navs/research.html %}
             <li class="nav-item">
-              <a class="nav-link{% if page.navbar == 'Education' %} active{% endif %}" href="{{ site.baseurl }}/education/index.html">Education</a>
-            </li>
-            <li class="nav-item">
               <a class="nav-link{% if page.navbar == 'References' %} active{% endif %}" href="{{ site.baseurl }}/references/index.html">References</a>
             </li>
           </ul>

--- a/education/index.md
+++ b/education/index.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: "Education"
-navbar: "Education"
-date: 2016-01-06 12:20
-navbar: Education
----

--- a/education/index.md
+++ b/education/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "Summer School"
-navbar: "SummerSchool"
+title: "Education"
+navbar: "Education"
 date: 2016-01-06 12:20
 navbar: Education
 ---

--- a/summer_school/index.md
+++ b/summer_school/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: "Education"
-navbar: "Education"
+title: "Summer School"
+navbar: "SummerSchool"
 date: 2016-01-06 12:20
 navbar: Education
 ---


### PR DESCRIPTION
First commit fixes #63 and second prepares a future section on summer schools. To "activate" the section, simply remove that those enclosing Liquid comment tags in `_includes/header.html`.

> Read the source, Luke.
