### PR TITLE
fix subnav active state on project page

### DIFF
--- a/_projects/activestorage_project.md
+++ b/_projects/activestorage_project.md
@@ -3,7 +3,8 @@ layout: page_project
 title: Exploiting Active Storage for Resilience
 date: 2016-01-01
 updated: 2016-02-05
-navbar: Projects
+navbar: Research
+subnavbar: Projects
 footer: true
 project_url:
 status: closing

--- a/_projects/fmm_project.md
+++ b/_projects/fmm_project.md
@@ -3,7 +3,8 @@ layout: page_project
 title: Scalability Enhancements to FMM for Molecular Dynamics Simulations
 date: 2016-01-01
 updated: 2016-02-05
-navbar: Projects
+navbar: Research
+subnavbar: Projects
 footer: true
 project_url:
 status: running

--- a/_projects/ichpc_project.md
+++ b/_projects/ichpc_project.md
@@ -3,7 +3,8 @@ layout: page_project
 title: Mitigating I/O Interference in Concurrent HPC Applications
 date: 2016-02-11
 updated:
-navbar: Projects
+navbar: Research
+subnavbar: Projects
 footer: true
 project_url:
 status: running

--- a/_projects/pmefr_project.md
+++ b/_projects/pmefr_project.md
@@ -3,7 +3,8 @@ layout: page_project
 title: Programming Model Extensions for Resilience
 date: 2016-02-10
 updated:
-navbar: Projects
+navbar: Research
+subnavbar: Projects
 footer: true
 project_url:
 status: starting

--- a/_templates/project_page
+++ b/_templates/project_page
@@ -3,7 +3,8 @@ layout: page_project
 title:
 date:
 updated:
-navbar: Projects
+navbar: Research
+subnavbar: Projects
 footer: true
 project_url:
 status:


### PR DESCRIPTION
When being on a specific project, the sub nav bar 'Research'->'Projects'
was not marked as 'active'.
