### PR TITLE
Fixing and individualizing contribute links

### DIFF
--- a/_includes/contribute_footer.html
+++ b/_includes/contribute_footer.html
@@ -4,10 +4,16 @@
   {% assign content = 'content' %}
 {% endif %}
 
+{% if include.link %}
+  {% assign link = include.link %}
+{% else %}
+  {% assign link = 'https://github.com/JLESC/jlesc.github.io/wiki' %}
+{% endif %}
+
 <footer id="contribute" class="card card-contribute text-xs-center small">
   <div class="card-block">
     <p class="card-text">
-      Want your {{ content }} to show up here? <a href="https://github.com/JLESC/jlesc.github.io/wiki">You can do it yourself</a>!
+      Want your {{ content }} to show up here? <a href="{{ link }}">You can do it yourself</a>!
     </p>
   </div>
 </footer>

--- a/about/people.md
+++ b/about/people.md
@@ -9,7 +9,7 @@ subnavbar: People
 <p class="lead">
   This is a list of people participating in the JLESC program.
   In case you are part of JLESC and not yet listed here, feel free to add yourself through a
-  <a href="https://github.com/JLESC/jlesc.github.io/wiki/Adding-Modifying-Content#people"
+  <a href="https://github.com/JLESC/jlesc.github.io/wiki/Editing-Data#editing-people"
      target="_blank">
     pull request on GitHub
   </a>.

--- a/events/index.html
+++ b/events/index.html
@@ -25,4 +25,7 @@ subnavbar: Overview
   </div>
 </div>
 
-{% include contribute_footer.html content='event' %}
+{% include contribute_footer.html
+  content='event'
+  link='https://github.com/JLESC/jlesc.github.io/wiki/Editing-Pages#editing-events'
+%}

--- a/news/index.html
+++ b/news/index.html
@@ -12,6 +12,11 @@ footer: false
   {% endfor %}
 </div>
 
+{% include contribute_footer.html
+  content='news'
+  link='https://github.com/JLESC/jlesc.github.io/wiki/Editing-Pages#editing-news'
+%}
+
 <nav class="row">
   <div class="col-xs-3 col-md-2">
     <a href="{% if paginator.next_page %}{{ paginator.next_page_path }}{% else %}#{% endif %}"

--- a/projects/index.html
+++ b/projects/index.html
@@ -78,4 +78,7 @@ subnavbar: Projects
   {% endfor %}
 </div>
 
-{% include contribute_footer.html content='project' %}
+{% include contribute_footer.html
+  content='project'
+  link='https://github.com/JLESC/jlesc.github.io/wiki/Editing-Pages#editing-projects'
+%}

--- a/references/index.html
+++ b/references/index.html
@@ -9,7 +9,8 @@ navbar: References
 <p class="lead">
   This list of publications closely related to the JLESC is probably not complete.
   Please feel free to add any missing publications through a
-  <a href="https://github.com/JLESC/jlesc.github.io/wiki" target="_blank">
+  <a href="https://github.com/JLESC/jlesc.github.io/wiki/Editing-Publications"
+     target="_blank">
     pull request on GitHub
   </a>.
 </p>

--- a/research/visits.md
+++ b/research/visits.md
@@ -7,6 +7,16 @@ navbar: Research
 subnavbar: Visits
 ---
 
+<p class="lead">
+  This is a list of visits members of the JLESC program made within JLESC.
+  In case your latest visit to your colleague at another JLESC partner is not yet listed here, feel
+  free to add yourself through a
+  <a href="https://github.com/JLESC/jlesc.github.io/wiki/Editing-Data#editing-visits"
+     target="_blank">
+    pull request on GitHub
+  </a>.
+</p>
+
 <div class="table-responsive">
   <table id="visits-db" class="table table-striped">
     <thead class="thead-default">

--- a/software/index.html
+++ b/software/index.html
@@ -32,4 +32,7 @@ subnavbar: Software
   {% endfor %}
 </div>
 
-{% include contribute_footer.html content='software' %}
+{% include contribute_footer.html
+  content='software'
+  link='https://github.com/JLESC/jlesc.github.io/wiki/Editing-Pages#editing-software'
+%}


### PR DESCRIPTION
Due to the recent changes in the wiki, some "_contribute here_" links were pointing to the wrong (or non-existent) location.

Also individualized the contribute footer. This can now point to the exact wiki page, e.g. for adding a project.
