### PR TITLE
Strip down News menu item

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,9 @@
         <div class="collapse navbar-toggleable-sm" id="CollapsingNavbar">
           <ul class="nav navbar-nav">
             {% include navs/about.html %}
-            {% include navs/news.html %}
+            <li class="nav-item">
+              <a href="{{ site.baseurl }}/news/index.html" class="nav-link{% if page.navbar == 'News' %} active{% endif %}">News</a>
+            </li>
             <li class="nav-item">
               <a class="nav-link{% if page.navbar == 'Events' %} active{% endif %}" href="{{ site.baseurl }}/events/index.html">Events</a>
             </li>

--- a/_includes/navs/news.html
+++ b/_includes/navs/news.html
@@ -1,7 +1,0 @@
-<li class="nav-item dropdown{% if page.navbar == 'News' %} active{% endif %}">
-  <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">News</a>
-  <div class="dropdown-menu">
-    <a href="{{ site.baseurl }}/news/index.html" class="dropdown-item{% if page.navbar == 'News' and page.subnavbar == 'Overview' %} active{% endif %}">Overview</a>
-    <a href="{{ site.baseurl }}/news/archive.html" class="dropdown-item{% if page.navbar == 'News' and page.subnavbar == 'Archive' %} active{% endif %}">Archive</a>
-  </div>
-</li>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,9 @@ layout: landingpage
         </ul>
       {% endif %}
       <div class="card-footer card-footer-slim text-muted text-xs-center small">
-        <a class="col-xs-6" href="{{ site.baseurl }}/news/archive.html">News Archive</a>
-        <a class="col-xs-6" href="{{ site.baseurl }}/feed.xml" title="subscribe via RSS">
+        <a class="col-xs-4" href="{{ site.baseurl }}/news/index.html">All</a>
+        <a class="col-xs-4" href="{{ site.baseurl }}/news/archive.html">Archive</a>
+        <a class="col-xs-4" href="{{ site.baseurl }}/feed.xml" title="subscribe via RSS">
           <i class="fa fa-rss"></i>
           <span class="hidden-sm-down">RSS</span>
         </a>

--- a/news/archive.html
+++ b/news/archive.html
@@ -2,8 +2,6 @@
 layout: page
 title: News Archive
 navbar: News
-subnavbar: Archive
-footer: false
 ---
 
 {% for post in site.posts reverse %}

--- a/news/index.html
+++ b/news/index.html
@@ -2,8 +2,6 @@
 layout: page
 title: News
 navbar: News
-subnavbar: Overview
-footer: false
 ---
 
 <div id="news-index">


### PR DESCRIPTION
It felt kind of clumsy having the 'News' menu item being a dropdown with
the two elements of 'Overview' and 'Archive'.

Now, the 'News' menu item is a simple link pointing to the news index
page. The news archive is accessible either via the news index page (at
the very bottom) or the landing page.
