### PR TITLE
Make visits table more versatile

### DIFF
--- a/_assets/css/main.scss
+++ b/_assets/css/main.scss
@@ -293,6 +293,18 @@ html {
       }
     }
 
+    #visits-db {
+      th.col-start,
+      th.col-end,
+      th.col-pm {
+        @extend .text-xs-center;
+      }
+
+      td.col-pm {
+        text-align: right;
+      }
+    }
+
     #statistics {
       .spacer {
         display: block;

--- a/_data/visits.yml
+++ b/_data/visits.yml
@@ -15,17 +15,35 @@
 # ## Require Attributes
 #
 #   from           ID (`_data/people.yml`) of the person traveling
-#   to             ID (`_data/people.yml`) of the person in the role of the host
-#   start          date of the start of the visit; format: YYYY-MM-DD
-#   end            date of the end of the visit; format: YYYY-MM-DD
+#   start          date of the start of the visit; format: YYYY-MM-DD; consult note below
+#   end            date of the end of the visit; format: YYYY-MM-DD; consult note below
+#
+#
+# ## Conditional Required Attributes
+#
+# exactly one of those has to be given:
+#
+#   to             ID (`_data/institutes.yml`) of the host institute
+#   invitee        ID (`_data/people.yml`) of the person inviting the visitor
+#
+# Whenever possible, the `invitee` form should be preferred.
+# Only in those cases, where there is no clear JLESCee individual inviting the traveling person the
+# first form stating the host institute should be used.
 #
 #
 # ## Optional Attributes
 #
-# -none-
+#   no_exact       give value 'true' if the start and/or end date is not the exact date;
+#                  see note blow on those dates
 #
 #
 # ## Notes
+#
+# - In those rare cases where the exact dates (exact day of month) of the travel can not be given
+#   we advice the following procedure:
+#     - specify the start date to be the first day of the month the visit started
+#     - specify the end date to be the last day of the month the visit ended
+#     - add the optional attribute 'no_exact' with a value of 'true'
 #
 # - stick to a total line length of 100 characters ................................ this is here ->|
 #   For longer text fields (e.g. 'topics') use YAML's "Folded style" [1]:
@@ -40,21 +58,26 @@
 # [1]: https://en.wikipedia.org/wiki/YAML#Newlines_folded
 #
 
+# this is a dummy entry
 - from: haensel_d
   to: balaji_p
   start: 2015-02-04
   end: 2015-02-15
 
-- from: haensel_d
-  to: balaji_p
+# this is a dummy entry
+- from: speck_r
+  host: riken
   start: 2016-02-04
   end: 2016-02-8
 
-- from: haensel_d
-  to: balaji_p
-  start: 2015-02-04
-  end: 2016-02-15
+# this is a dummy entry
+- from: klatt_t
+  to: speck_r
+  start: 2015-11-01
+  end: 2016-03-31
+  no_exact: true
 
+# this is a dummy entry
 - from: haensel_d
   to: balaji_p
   start: 2015-12-04

--- a/research/visits.md
+++ b/research/visits.md
@@ -23,9 +23,9 @@ subnavbar: Visits
       <tr>
         <th class="col-visitor">Visitor</th>
         <th class="col-host">Host</th>
-        <th class="col-start">From</th>
-        <th class="col-end">To</th>
-        <th class="col-pm"><abbr title="Person-Months">PM</abbr></th>
+        <th class="col-start">Start</th>
+        <th class="col-end">End</th>
+        <th class="col-pm"><abbr title="Person-Months (see note below)">PM</abbr></th>
       </tr>
     </thead>
     <tbody>
@@ -34,7 +34,13 @@ subnavbar: Visits
         {% assign visit_duration = visit.end | date:"%s" | minus:visit_start_stamp %}
         <tr>
           <td class="col-visitor">{% person_inverse {{ visit.from }} %}</td>
-          <td class="col-host">{% person_inverse {{ visit.to }} %}</td>
+          <td class="col-host">
+            {% if visit.to %}
+              {% person_inverse {{ visit.to }} %}
+            {% else %}
+              {% institute {{ visit.host }} %}
+            {% endif %}
+          </td>
           <td class="col-start">
             {{ visit.start | date_to_string }}
           </td>
@@ -42,7 +48,12 @@ subnavbar: Visits
             {{ visit.end | date_to_string }}
           </td>
           <td class="col-pm">
-            <abbr title="{% duration_humanized {{ visit_duration }} %}">
+            {% if visit.no_exact %}
+              <abbr title="start date and/or end date is not exact" class="pull-left">
+                <i class="fa fa-fw fa-exclamation"></i>
+              </abbr>
+            {% endif %}
+            <abbr title="{% if visit.no_exact %}roughly {% endif %}{% duration_humanized {{ visit_duration }} %}">
               {% duration_pms {{ visit_duration }} %}
             </abbr>
           </td>
@@ -55,4 +66,5 @@ subnavbar: Visits
 <p class="text-muted">
   The amount of <em>Person-Months</em> is computed from the start and end date of each visit with
   the assumption of 30 days per month.
+  The values are rounded to a quarter of a <em>PM</em>.
 </p>


### PR DESCRIPTION
Now also allowing for institutes as hosts and also denoting those visits
which can not state exact dates for the duration of the stay.
