### PR TITLE
Nicer permalinks for events and news

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,9 @@ paginate_path: "/news/page:num/"
 
 excerpt_separator: '<!--more-->'
 
+# this is used for news posts
+permalink: /news/:year/:month/:day/:slug/
+
 assets:
   compress:
     css: true
@@ -70,8 +73,10 @@ assets:
 collections:
   events_upcoming:
     output: true
+    permalink: /events/:slug/
   events_past:
     output: true
+    permalink: /events/:slug/
   software:
     output: true
   projects:


### PR DESCRIPTION
Events now keep their permanent URL when moved from 'upcoming' to 'past'
and are always found in /events/SLUG.

Similar, news posts are now always found in /news/YEAR/MONTH/DAY/SLUG

In addition, a sub directory is created for each event,
allowing for detailed pages for each event.

Example:
`2016-02-15-dummy-event.md` will create the following structure in the
generated website:

```
events/
  dummy-event/
    index.html
```

People/users have not the possibility to create a subdirectory
`dummy-event` in `events/` with additional markdown files, e.g. for
workshop details.
