### PR TITLE
Fix URLs and links to pages

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -4,7 +4,7 @@
 #
 # ## Purpose
 #
-# - data source for the table on `about/people.html`
+# - data source for the table on `about/people/`
 # - data source for custom _person_ Liquid tags
 #
 #

--- a/_data/visits.yml
+++ b/_data/visits.yml
@@ -4,7 +4,7 @@
 #
 # ## Purpose
 #
-# - data source for the table on `research/visits.html`
+# - data source for the table on `research/visits/`
 #
 #
 # ## Identifier Format

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <div class="row small">
         <div class="col-xs-6 col-sm-3">
           <div class="nav navbar-nav">
-            <a class="nav-link" href="{{ site.baseurl }}/about/imprint.html">
+            <a class="nav-link" href="{{ site.baseurl }}/about/imprint/">
               <i class="fa fa-copyright fa-fw"></i><span class="hidden-md-down">Imprint</span></a>
           </div>
         </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,14 +23,14 @@
           <ul class="nav navbar-nav">
             {% include navs/about.html %}
             <li class="nav-item">
-              <a href="{{ site.baseurl }}/news/index.html" class="nav-link{% if page.navbar == 'News' %} active{% endif %}">News</a>
+              <a href="{{ site.baseurl }}/news/" class="nav-link{% if page.navbar == 'News' %} active{% endif %}">News</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link{% if page.navbar == 'Events' %} active{% endif %}" href="{{ site.baseurl }}/events/index.html">Events</a>
+              <a class="nav-link{% if page.navbar == 'Events' %} active{% endif %}" href="{{ site.baseurl }}/events/">Events</a>
             </li>
             {% include navs/research.html %}
             <li class="nav-item">
-              <a class="nav-link{% if page.navbar == 'References' %} active{% endif %}" href="{{ site.baseurl }}/references/index.html">References</a>
+              <a class="nav-link{% if page.navbar == 'References' %} active{% endif %}" href="{{ site.baseurl }}/references/">References</a>
             </li>
           </ul>
 

--- a/_includes/navs/about.html
+++ b/_includes/navs/about.html
@@ -1,9 +1,9 @@
 <li class="nav-item dropdown{% if page.navbar == 'About' %} active{% endif %}">
   <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">About</a>
   <div class="dropdown-menu">
-    <a href="{{ site.baseurl }}/about/index.html" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Overview' %} active{% endif %}">JLESC</a>
-    <a href="{{ site.baseurl }}/about/partners.html" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Partners' %} active{% endif %}">Partners</a>
-    <a href="{{ site.baseurl }}/about/people.html" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'People' %} active{% endif %}">People</a>
-    <a href="{{ site.baseurl }}/about/grants.html" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Grants' %} active{% endif %}">Grants</a>
+    <a href="{{ site.baseurl }}/about/" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Overview' %} active{% endif %}">JLESC</a>
+    <a href="{{ site.baseurl }}/about/partners/" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Partners' %} active{% endif %}">Partners</a>
+    <a href="{{ site.baseurl }}/about/people/" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'People' %} active{% endif %}">People</a>
+    <a href="{{ site.baseurl }}/about/grants/" class="dropdown-item{% if page.navbar == 'About' and page.subnavbar == 'Grants' %} active{% endif %}">Grants</a>
   </div>
 </li>

--- a/_includes/navs/research.html
+++ b/_includes/navs/research.html
@@ -1,9 +1,9 @@
 <li class="nav-item dropdown{% if page.navbar == 'Groups' or page.navbar == 'Projects' or page.navbar == 'Research' %} active{% endif %}">
   <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Research</a>
   <div class="dropdown-menu">
-    <a href="{{ site.baseurl }}/research/collaboration.html" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Collaboration' %} active{% endif %}">On Collaboration</a>
-    <a href="{{ site.baseurl }}/projects/index.html" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Projects' %} active{% endif %}">Projects</a>
-    <a href="{{ site.baseurl }}/software/index.html" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Software' %} active{% endif %}">Software</a>
-    <a href="{{ site.baseurl }}/research/visits.html" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Visits' %} active{% endif %}">Visits</a>
+    <a href="{{ site.baseurl }}/research/collaboration/" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Collaboration' %} active{% endif %}">On Collaboration</a>
+    <a href="{{ site.baseurl }}/projects/" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Projects' %} active{% endif %}">Projects</a>
+    <a href="{{ site.baseurl }}/software/" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Software' %} active{% endif %}">Software</a>
+    <a href="{{ site.baseurl }}/research/visits/" class="dropdown-item{% if page.navbar == 'Research' and page.subnavbar == 'Visits' %} active{% endif %}">Visits</a>
   </div>
 </li>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@ layout: landingpage
         </ul>
       {% endif %}
       <div class="card-footer card-footer-slim text-muted text-xs-center small">
-        <a class="col-xs-4" href="{{ site.baseurl }}/news/index.html">All</a>
-        <a class="col-xs-4" href="{{ site.baseurl }}/news/archive.html">Archive</a>
+        <a class="col-xs-4" href="{{ site.baseurl }}/news/">All</a>
+        <a class="col-xs-4" href="{{ site.baseurl }}/news/archive/">Archive</a>
         <a class="col-xs-4" href="{{ site.baseurl }}/feed.xml" title="subscribe via RSS">
           <i class="fa fa-rss"></i>
           <span class="hidden-sm-down">RSS</span>
@@ -84,7 +84,7 @@ layout: landingpage
         </ul>
       {% endif %}
       <div class="card-footer card-footer-slim text-muted text-xs-center small">
-        <a href="{{ site.baseurl }}/events/index.html">All Events</a>
+        <a href="{{ site.baseurl }}/events/">All Events</a>
       </div>
     </div>
   </div>

--- a/news/index.html
+++ b/news/index.html
@@ -25,7 +25,7 @@ navbar: News
     </a>
   </div>
   <div class="col-xs-6 col-md-4 col-md-offset-2">
-    <a href="{{ site.baseurl }}/news/archive.html" class="btn btn-sm btn-secondary btn-block" role="button">
+    <a href="{{ site.baseurl }}/news/archive/" class="btn btn-sm btn-secondary btn-block" role="button">
       <span class="hidden-sm-down">News </span>Archive
     </a>
   </div>


### PR DESCRIPTION
Recent changes in the local Jekyll configuration broke a few of the
inter-page links. Especially, it is not required any more to link to a
specific `somehwere/index.html` site or to `/grants.html`. Instead, we
use the more user and search engine friendly `/somehwere/` and
`/grants/` scheme.
