### PR TITLE
Count leading a project as participation

### DIFF
--- a/_plugins/statistics_tag.rb
+++ b/_plugins/statistics_tag.rb
@@ -67,6 +67,7 @@ module JLESC
           statistics['institutes'][head['affiliation']]['leading'] += 1
         end
         statistics['people'][project.data['head']]['projects']['leading'] += 1
+        statistics['people'][project.data['head']]['projects']['participating'] += 1
       end
 
       inst = []

--- a/about/people.html
+++ b/about/people.html
@@ -33,7 +33,7 @@ subnavbar: People
              data-toggle="tooltip"></i>
         </th>
         <th class="col-leading">
-          <i class="fa fa-fw fa-graduation-cap" title="leading # projects"
+          <i class="fa fa-fw fa-graduation-cap" title="thereof leading # projects"
              data-toggle="tooltip"></i>
         </th>
         <th class="col-topics">Topics</th>


### PR DESCRIPTION
Also renamed `/about/people.md` to `*.html` as no Markdown but a whole bunch
of HTML is used.

fixes #116
