### PR TITLE
Add TOC for project pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'jekyll-feed'
 gem 'jekyll-assets'
 gem 'jekyll-sitemap'
 gem 'jekyll-scholar'
+gem 'jekyll-toc', github: 'torbjoernk/jekyll-toc',
+                  branch: 'feature/separate-filters'
 gem 'jekyll-git_metadata', github: 'torbjoernk/jekyll-git_metadata',
                            tag: 'v0.0.5-torbjoernk'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
     jekyll-git_metadata (0.0.5.pre.torbjoernk)
       jekyll (~> 3.0)
 
+GIT
+  remote: git://github.com/torbjoernk/jekyll-toc.git
+  revision: c5df2e5077ab55b39d7f084797a1d7894d4447ba
+  branch: feature/separate-filters
+  specs:
+    jekyll-toc (0.0.5)
+      nokogiri (~> 1.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -76,7 +84,10 @@ GEM
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
     mini_magick (4.3.6)
+    mini_portile2 (2.0.0)
     namae (0.10.1)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     rack (1.6.4)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
@@ -110,6 +121,7 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-scholar
   jekyll-sitemap
+  jekyll-toc!
   jekyll-watch
   jgd
   mini_magick

--- a/_assets/css/_toc.scss
+++ b/_assets/css/_toc.scss
@@ -1,0 +1,29 @@
+#toc {
+  ul {
+    @extend .list-group;
+    @extend .list-group-flush;
+
+    li {
+      @extend .list-group-item;
+      padding-top: ($spacer-y / 2);
+      padding-bottom: ($spacer-y / 2);
+
+      &:first-child {
+        border-top: 0;
+      }
+
+      &.toc-entry {
+        &.toc-h1 {}
+
+        &.toc-h2 {}
+
+        &.toc-h3,
+        &.toc-h4,
+        &.toc-h5,
+        &.toc-h6 {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/_assets/css/main.scss
+++ b/_assets/css/main.scss
@@ -14,6 +14,7 @@
 @import 'global';
 @import 'index';
 @import 'asides';
+@import 'toc';
 @import 'github_box';
 @import 'people';
 @import 'news';

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ markdown: kramdown
 gems:
   - jekyll-assets
   - jekyll-paginate
+  - jekyll-toc
   - jekyll-feed
   - jekyll-git_metadata
   - jekyll/scholar
@@ -42,6 +43,13 @@ paginate: 5
 paginate_path: "/news/page:num/"
 
 excerpt_separator: '<!--more-->'
+
+defaults:
+  -
+    scope:
+      path: ''
+    values:
+      toc: true
 
 # this is used for news posts
 permalink: /news/:year/:month/:day/:slug/

--- a/_layouts/page_project.html
+++ b/_layouts/page_project.html
@@ -11,12 +11,18 @@ layout: default
     <div class="row">
       <aside class="col-lg-5 col-sm-12 pull-lg-right collapse in" id="meta-aside">
         {% include asides/project_meta.html %}
+        <section class="card" id="toc">
+          <div class="card-header">
+            Table of Content
+          </div>
+          {{ content | toc_only }}
+        </section>
       </aside>
       <div class="col-lg-7 col-sm-12 pull-lg-left content" id="main-content">
         {% if page.subtitle %}
           <h2>{{ page.subtitle }}</h2>
         {% endif %}
-        {{ content }}
+        {{ content | inject_anchors }}
       </div>
     </div>
   </article>


### PR DESCRIPTION
Thanks to a little hacking on the jekyll-toc plugin, the TOC can now be
placed wherever desired.

With some CSS I'm displaying only TOC entries of the first and second
level, i.e. H1 ()#`in Markdown) and H2 (`##` in Markdown).

Remember to do a `bundle install --clean`.

fixes #109
