### PR TITLE
Better event location links

### DIFF
--- a/_assets/css/_events.scss
+++ b/_assets/css/_events.scss
@@ -9,6 +9,18 @@
 }
 
 
+footer.event-meta {
+  .card:last-child {
+    .card-block {
+      white-space: nowrap;
+      word-break: keep-all;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
+
 #schedule-accordion {
   a.abstract-btn {
     @extend .tag;

--- a/_assets/css/_index.scss
+++ b/_assets/css/_index.scss
@@ -6,5 +6,14 @@
 ul#next-events-index {
   li {
     padding: 0.75rem 0.25rem !important;
+
+    .row.small {
+      div {
+        white-space: nowrap;
+        word-break: keep-all;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
   }
 }

--- a/_events_upcoming/2016-02-28-1st-dummy-outreach.md
+++ b/_events_upcoming/2016-02-28-1st-dummy-outreach.md
@@ -4,7 +4,7 @@ title: 1st Dummy Outreach Event
 date: 2016-02-15
 updated:
 navbar: Events
-event_location: Milky Way
+event_location: Milky Way, The Galaxy
 event_start: 2016-02-28
 event_end: 2016-03-01
 event_short_url:

--- a/_includes/asides/event_meta.html
+++ b/_includes/asides/event_meta.html
@@ -11,23 +11,35 @@
     {% image {{\ page.logo\ }} class:"img-fluid p-a-1" alt:"{{ page.title }} Logo" %}
   {% endif %}
   <ul class="list-group list-group-flush">
-    {% if page.event_url %}
-      <li class="list-group-item row">
-        <label class="col-sm-4">Homepage</label>
-        <div class="col-sm-8">
-          <a href="{{ page.event_url }}" target="_blank">{% if page.event_short_url %}{{ page.event_short_url }}{% else %}{{ page.event_url | trim_url }}{% endif %}</a>
-          {% if page.wayback_url %}
-            <span class="pull-right">
-              <a href="{{ page.wayback_url }}" target="_blank"
-                 title="Event web site in Archive.org Wayback machine"
-                 data-toggle="tooltip">
-                <i class="fa fa-history fa-fw"></i>
-              </a>
-            </span>
-          {% endif %}
-        </div>
-      </li>
-    {% endif %}
+    <li class="list-group-item row">
+      <label class="col-sm-4">Homepage</label>
+      <div class="col-sm-8">
+        <a {% if page.event_url | size > 0 %}
+             href="{{ page.event_url }}" target="_blank"
+             class="btn btn-sm btn-link"
+             title="Event's homepage"
+           {% else %}
+             aria-disabled="true"
+             class="btn btn-sm btn-link disabled"
+             title="Event's homepage not available"
+           {% endif %}
+           data-toggle="tooltip"
+           role="button">
+          <i class="fa fa-fw fa-globe"></i></a>
+        <a {% if page.wayback_url | size > 0 %}
+             href="{{ page.wayback_url }}" target="_blank"
+             class="btn btn-sm btn-link"
+             title="Event's homepage in Archive.org Wayback machine"
+           {% else %}
+             aria-disabled="true"
+             class="btn btn-sm btn-link disabled"
+             title="Event's homepage not available in Archive.org's Wayback machine"
+           {% endif %}
+           role="button"
+           data-toggle="tooltip">
+          <i class="fa fa-history fa-fw"></i></a>
+      </div>
+    </li>
     {% if page.event_start and page.event_start == page.event_end %}
       <li class="list-group-item row">
         <label class="col-sm-4">Date</label>
@@ -52,7 +64,15 @@
     <li class="list-group-item row">
       <label class="col-sm-4">Location</label>
       <div class="col-sm-8">
-        {% if page.event_location %}{{ page.event_location }}{% else %}tba{% endif %}
+        {% if page.event_location %}
+          <a href="https://google.com/maps/search/{{ page.event_location | replace:' ','+' }}"
+             target="_blank" class="btn btn-sm btn-link"
+             role="button" title="Search on Google Maps" data-toggle="tooltip">
+            <i class="fa fa-fw fa-map-marker"></i></a>
+          {{ page.event_location }}
+        {% else %}
+          <span title="to be announced" data-toggle="tooltip">tba</span>
+        {% endif %}
       </div>
     </li>
     {% if page.institute %}

--- a/_includes/event/meta.html
+++ b/_includes/event/meta.html
@@ -25,9 +25,13 @@
       <i class="fa fa-stop fa-fw"></i>
       {% if event.event_end %}<time datetime="{{ event.event_end | datetime | date_to_xmlschema }}">{{ event.event_end | date_to_string }}</time>{% else %}tba{% endif %}
     </div>
-    <div class="col-xs-12 col-sm-4" title="Event's location" data-toggle="tooltip" data-placement="bottom">
+    <div class="col-xs-12 col-sm-4" title="Event's location{% if event.event_location %}. Find on Google Maps!{% endif %}" data-toggle="tooltip" data-placement="bottom">
+      {% if event.event_location %}
+      <a href="https://google.com/maps/search/{{ event.event_location | replace:' ','+' }}" target="_blank">
+        {% endif %}
       <i class="fa fa-map-marker fa-fw"></i>
       {% if event.event_location %}{{ event.event_location }}{% else %}tba{% endif %}
+        {% if event.event_location %}</a>{% endif %}
     </div>
   {% endif %}
 
@@ -60,9 +64,13 @@
         </div>
       {% endif %}
       <div class="card">
-        <div class="card-block" title="Event's location" data-toggle="tooltip" data-placement="bottom">
+        <div class="card-block" title="Event's location{% if event.event_location %}. Find on Google Maps!{% endif %}" data-toggle="tooltip" data-placement="bottom">
+          {% if event.event_location %}
+            <a href="https://google.com/maps/search/{{ event.event_location | replace:' ','+' }}" target="_blank">
+          {% endif %}
           <i class="fa fa-map-marker fa-fw"></i>
           {% if event.event_location %}{{ event.event_location }}{% else %}tba{% endif %}
+          {% if event.event_location %}</a>{% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
1. the event's location marker now links to Google Maps
2. in an event's aside the event's URL is now a simple button, not a
   full text potentially overflowing and wrapping around

In case the event hasn't an URL given, the homepage buttons are
disabled. However, due to a bug in Twitter Bootstrap
(twbs/bootstrap#19322), the tooltip is not shown.

fixes #125 and #126
