### PR TITLE
Beautify event location on overview page

### DIFF
--- a/_assets/css/_events.scss
+++ b/_assets/css/_events.scss
@@ -10,13 +10,13 @@
 
 
 footer.event-meta {
-  .card:last-child {
-    .card-block {
-      white-space: nowrap;
-      word-break: keep-all;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+  @extend small;
+
+  div:last-child {
+    white-space: nowrap;
+    word-break: keep-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/_includes/event/meta.html
+++ b/_includes/event/meta.html
@@ -2,77 +2,53 @@
   {% assign event = page %}
 {% endunless %}
 
-{% if on_global_index %}
-  {% if event.event_start == event.event_end %}
-    <div class="col-xs-12 col-sm-6" title="Event's date" data-toggle="tooltip" data-placement="bottom">
-      <i class="fa fa-play"></i> / <i class="fa fa-stop"></i>
-      {% if event.event_start %}
-        <time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>
-      {% else %}
-        tba
-      {% endif %}
-    </div>
-    <div class="col-xs-12 col-sm-6" title="Event's location" data-toggle="tooltip" data-placement="bottom">
-      <i class="fa fa-map-marker fa-fw"></i>
-      {% if event.event_location %}{{ event.event_location }}{% else %}tba{% endif %}
-    </div>
-  {% else %}
-    <div class="col-xs-12 col-sm-4" title="Event's start date" data-toggle="tooltip" data-placement="bottom">
-      <i class="fa fa-play fa-fw"></i>
-      {% if event.event_start %}<time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>{% else %}tba{% endif %}
-    </div>
-    <div class="col-xs-12 col-sm-4" title="Event's end date" data-toggle="tooltip" data-placement="bottom">
-      <i class="fa fa-stop fa-fw"></i>
-      {% if event.event_end %}<time datetime="{{ event.event_end | datetime | date_to_xmlschema }}">{{ event.event_end | date_to_string }}</time>{% else %}tba{% endif %}
-    </div>
-    <div class="col-xs-12 col-sm-4" title="Event's location{% if event.event_location %}. Find on Google Maps!{% endif %}" data-toggle="tooltip" data-placement="bottom">
-      {% if event.event_location %}
-      <a href="https://google.com/maps/search/{{ event.event_location | replace:' ','+' }}" target="_blank">
-        {% endif %}
-      <i class="fa fa-map-marker fa-fw"></i>
-      {% if event.event_location %}{{ event.event_location }}{% else %}tba{% endif %}
-        {% if event.event_location %}</a>{% endif %}
-    </div>
-  {% endif %}
-
+{% if event.event_start == event.event_end %}
+  <div class="col-xs-12 col-sm-6" title="Event's date" data-toggle="tooltip" data-placement="bottom">
+    <i class="fa fa-play"></i> / <i class="fa fa-stop"></i>
+    {% if event.event_start %}
+      <time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>
+    {% else %}
+      tba
+    {% endif %}
+  </div>
+  <div class="col-xs-12 col-sm-6" title="Event's location" data-toggle="tooltip" data-placement="bottom">
+    <i class="fa fa-map-marker fa-fw"></i>
+    {% if event.event_location %}
+      {{ event.event_location }}
+    {% else %}
+      tba
+    {% endif %}
+  </div>
 {% else %}
-  <footer class="event-meta card-deck-wrapper small">
-    <div class="card-deck">
-      {% if event.event_start == event.event_end %}
-        <div class="card">
-          <div class="card-block" title="Event's date" data-toggle="tooltip" data-placement="bottom">
-            <i class="fa fa-play"></i> / <i class="fa fa-stop"></i>
-            {% if event.event_start %}
-              <time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>
-            {% else %}
-              tba
-            {% endif %}
-          </div>
-        </div>
-      {% else %}
-        <div class="card">
-          <div class="card-block" title="Event's start date" data-toggle="tooltip" data-placement="bottom">
-            <i class="fa fa-play fa-fw"></i>
-            {% if event.event_start %}<time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>{% else %}tba{% endif %}
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-block" title="Event's end date" data-toggle="tooltip" data-placement="bottom">
-            <i class="fa fa-stop fa-fw"></i>
-            {% if event.event_end %}<time datetime="{{ event.event_end | datetime | date_to_xmlschema }}">{{ event.event_end | date_to_string }}</time>{% else %}tba{% endif %}
-          </div>
-        </div>
-      {% endif %}
-      <div class="card">
-        <div class="card-block" title="Event's location{% if event.event_location %}. Find on Google Maps!{% endif %}" data-toggle="tooltip" data-placement="bottom">
-          {% if event.event_location %}
-            <a href="https://google.com/maps/search/{{ event.event_location | replace:' ','+' }}" target="_blank">
-          {% endif %}
-          <i class="fa fa-map-marker fa-fw"></i>
-          {% if event.event_location %}{{ event.event_location }}{% else %}tba{% endif %}
-          {% if event.event_location %}</a>{% endif %}
-        </div>
-      </div>
-    </div>
-  </footer>
+  <div class="col-xs-6 {% if on_global_index %}col-sm-4{% else %}col-lg-4{% endif %}"
+       title="Event's start date" data-toggle="tooltip" data-placement="bottom">
+    <i class="fa fa-play fa-fw"></i>
+    {% if event.event_start %}
+      <time datetime="{{ event.event_start | datetime | date_to_xmlschema }}">{{ event.event_start | date_to_string }}</time>
+    {% else %}
+      tba
+    {% endif %}
+  </div>
+  <div class="col-xs-6 {% if on_global_index %}col-sm-4{% else %}col-lg-4{% endif %}" title="Event's end date" data-toggle="tooltip" data-placement="bottom">
+    <i class="fa fa-stop fa-fw"></i>
+    {% if event.event_end %}
+      <time datetime="{{ event.event_end | datetime | date_to_xmlschema }}">{{ event.event_end | date_to_string }}</time>
+    {% else %}
+      tba
+    {% endif %}
+  </div>
+  <div class="col-xs-12 {% if on_global_index %}col-sm-4{% else %}col-lg-4{% endif %}">
+    {% if event.event_location %}
+      <a href="https://google.com/maps/search/{{ event.event_location | replace:' ','+' }}" target="_blank"
+         title="Event's location: {{ event.event_location }}. Find on Google Maps!"
+         data-toggle="tooltip" data-placement="bottom">
+    {% endif %}
+    <i class="fa fa-map-marker fa-fw"></i>
+    {% if event.event_location %}
+      {{ event.event_location }}
+    {% else %}
+      tba
+    {% endif %}
+    {% if event.event_location %}</a>{% endif %}
+  </div>
 {% endif %}

--- a/_includes/event/overview_item.html
+++ b/_includes/event/overview_item.html
@@ -1,7 +1,9 @@
-<li class="list-group-item">
-  <span class="list-group-item-heading">
+<li class="list-group-item container">
+  <div class="list-group-item-heading row col-xs-12">
     <label class="tag tag-event-{{ event.kind }}">{% event_kind {{ event.kind }} %}</label>
     <a href="{{site.baseurl}}{{ event.url }}">{{ event.title }}</a>
-  </span>
-  {% include event/meta.html %}
+  </div>
+  <footer class="event-meta row">
+    {% include event/meta.html %}
+  </footer>
 </li>

--- a/events/index.html
+++ b/events/index.html
@@ -6,7 +6,7 @@ navbar: Events
 ---
 
 <div class="row">
-  <div class="col-md-6">
+  <div class="col-xs-12 col-md-6">
     <h2>Upcoming</h2>
     <ul class="list-group">
       {% sorted_for event in site.events_upcoming sort_by:event_start %}
@@ -16,7 +16,7 @@ navbar: Events
       {% endsorted_for %}
     </ul>
   </div>
-  <div class="col-md-6">
+  <div class="col-xs-12 col-md-6">
     <h2>Past</h2>
     <ul class="list-group">
       {% sorted_for event in site.events_past reversed sort_by:event_start %}


### PR DESCRIPTION
- use equal-width boxes for event's dates and location
- clip off long event locations by ellipsis and put full event location
  into tooltip

fixes #130
