### PR TITLE
Added standard acknowledgement for JLESC publications. This fixes #137.

### DIFF
--- a/references/index.html
+++ b/references/index.html
@@ -7,12 +7,13 @@ navbar: References
 ---
 
 <p class="lead">
-  This list of publications closely related to the JLESC is probably not complete.
-  Please feel free to add any missing publications through a
+  This is a list of publications closely related to the JLESC. Please feel free to add any missing publications through a
   <a href="https://github.com/JLESC/jlesc.github.io/wiki/Editing-Publications"
      target="_blank">
     pull request on GitHub
   </a>.
+  <br><br>
+  If you publish something during your work within JLESC, please acknowledge JLESC support e.g. via "This research is partially supported by the NCSA-Inria-ANL-BSC-JSC-Riken Joint-Laboratory on Extreme Scale Computing (JLESC)."
 </p>
 
 <div class="row">


### PR DESCRIPTION
Signed-off-by: Robert Speck r.speck@fz-juelich.de
