### PR TITLE
Removed PMs from the website

### DIFF
--- a/_projects/Lossy_checkpoint_restart.md
+++ b/_projects/Lossy_checkpoint_restart.md
@@ -43,13 +43,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person cappello_f %} | 1 PM |
-| {% person olson_l %} | 1 PM |
-| {% person calhoun_j %} | 3 PM |
-
 ## Future plans
 
 Jon Calhoun will spend the summer at ANL with Franck Cappello for an internship.

--- a/_projects/activestorage_project.md
+++ b/_projects/activestorage_project.md
@@ -57,18 +57,6 @@ The project has submitted a publication to ISC16 that has been accepted.
 -->
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-The efforts of the participants so far are as follows:
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person chien_a %}        | 0.1 PM |
-| {% person pleiter_d %}      | 0.1 PM |
-| {% person dun_n %}          | 2.0 PM |
-| {% person vandenbergen_n %} | 0.5 PM |
-
-
 ## Future plans
 None
 

--- a/_projects/aggregator_placement.md
+++ b/_projects/aggregator_placement.md
@@ -77,16 +77,6 @@ Remember to use the `--file jlesc.bib` with the `cite` tag.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person jeannot_e %} | 0.5 PM |
-| {% person tessier_f %} | 3.0 PM |
-| {% person vishwanath_v %} | 0.5 PM |
-
-
-
 ## Future plans
 
 The next step will be to determine the parameters to consider to compute a near-optimal number of aggregators.

--- a/_projects/alya_project.md
+++ b/_projects/alya_project.md
@@ -48,16 +48,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person agullo_e %} | 0.25 PM |
-| {% person artigues_a %} | 2 PM |
-| {% person houzeaux_g %} | 2 PM |
-| {% person ramet_p %} | 0.25 PM |
-| {% person vazquez_m %} | 0.5 PM |
-
-
 ## Future plans
 We intend to complete the full integration of the Inria solvers with their current individual API in the Alya code so that scalability studies on different applications representative of Alya simulations can be performed (incompressible/compressible fluid, structure mechanics).
 Hopefully some of them will reveal numerical or software features to be further studied.

--- a/_projects/chase_bse_project.md
+++ b/_projects/chase_bse_project.md
@@ -85,32 +85,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-The steps carried out so far to prepare this project have not taken
-significant person-month efforts (on the order of 1 person-day).
-
-{% comment %}
-=========================================
-== ADD A TABLE OF PERSON-MONTH EFFORTS ==
-
-Put it in the following form, each person on its own line
-
-| {% person PERSON_ID %} | X.Y PM |
-
-e.g.:
-
-| {% person kabadshow_i %} | 2.0 PM |
-
-Above the very first person put the following line:
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-
-==================================
-== START HERE ==
-{% endcomment %}
-
-
 ## Future plans
 
 The next step is to implement the ChASE library into the Jena BSE code

--- a/_projects/dense_eigen_project.md
+++ b/_projects/dense_eigen_project.md
@@ -93,13 +93,6 @@ Remember to use the `--file jlesc.bib` with the `cite` tag.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person imamura_t %}    | 0.5 PM |
-| {% person gutheil_i %} | 0.5 PM |
-
-
 ## Future plans
 
 In 2016, we divide the first year into 1st and 2nd halves on the management of this project.

--- a/_projects/eandb_project.md
+++ b/_projects/eandb_project.md
@@ -110,17 +110,6 @@ This work was presented at the HiPC conference {% cite PadoinEtAl2014 --file ext
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person keller_tesser_r %}    | 6 PM |
-| {% person padoin_e %} | 4 PM |
-| {% person navaux_p %}   | 1 PM   |
-| {% person mendes_c %} | 0.5 PM |
-| {% person kale_s %}   | 0.25 PM   |
-| {% person mehaut_j %}   | 1 PM   |
-
-
 ## Future plans
 
 * Using simulations (SimGrid, BigSim, Dimemas) for the design and analysis of load balancers

--- a/_projects/elastic_prov.md
+++ b/_projects/elastic_prov.md
@@ -38,15 +38,6 @@ We carried out a set of experiments using an application relying on input from s
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person keahey_k %} | 0.5 PM |
-| {% person antoniu_g %} | 0.5 PM |
-| {% person pineda_morales_l %} | 4.0 PM |
-| {% person subramaniam_b %} | 4.0 PM |
-| {% person costan_a %} | 4.0 PM |
-
 ## Future plans
 
 Next steps include experimenting with Phantom auto-scaling service {% cite KeaheyEtAl2012 --file external/elastic_prov.bib %} in the Chameleon cloud to elastically provision resources for our use case application.

--- a/_projects/exec_interfer_project.md
+++ b/_projects/exec_interfer_project.md
@@ -49,14 +49,6 @@ We rather translate these constraints in geometric properties: allocations have 
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person trystram_d %} | 0.5 PM |
-| {% person wagner_f %} | 0.5 PM |
-| {% person lucarelli_g %} | 0.5 PM |
-| {% person bleuse_r %} | 1.5 PM |
-
 
 ## Future plans
 

--- a/_projects/extreme_scale_workflows.md
+++ b/_projects/extreme_scale_workflows.md
@@ -43,18 +43,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person wozniak_j %} | 1 PM |
-| {% person peterka_t %} | 1 PM |
-| {% person dreher_m %} | 1 PM |
-| {% person ross_r %} | 1 PM |
-| {% person antoniu_g %} | 1 PM |
-| {% person ibrahim_s %} | 1 PM |
-| {% person dorier_m %} | 1 PM |
-| {% person raffin_b %} | 1 PM |
-
 ## Future plans
 
 This summer we will implement the main integration between Decaf and Swift. A paper about the MPI details of integration between Swift and Decaf would be a good submission to EuroMPI. A paper about realistic LAMMPS or HACC simulation/analysis workflows would be a good submission to SC.

--- a/_projects/fmm_project.md
+++ b/_projects/fmm_project.md
@@ -48,17 +48,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person balaji_p %}    | 0.25 PM |
-| {% person kabadshow_i %} | 0.25 PM |
-| {% person haensel_d %}   | 3 PM   |
-| {% person amer_a %}   | 1 PM   |
-
-The efforts are likely to increase, once the code base includes a near-complete parallelization layer.
-
-
 ## Future plans
 Currently we are developing a task-based scheme to simplify the use of shared memory and to improve intranode load-balancing. Therefore, the FMM software layout has to be extended to support asynchronous execution, task-dependency resolvability and tasking itself.
 In a second step the FMM will be coupled with currently available low-level tasking frameworks like Argobots.

--- a/_projects/folding_hmem.md
+++ b/_projects/folding_hmem.md
@@ -47,17 +47,6 @@ We are writing a paper and seeking further funding.
 
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person pena_a %} | 1.0 PM |
-| {% person servat_h %} | 1.0 PM |
-| {% person oden_l %} | 0.5 PM |
-| {% person gimenez_j %} | 0.5 PM |
-| {% person labarta_j %} | 0.5 PM |
-| {% person balaji_p %} | 0.5 PM |
-
 ## Future plans
 Validate the sampling technique for data distribution by implementing and evaluating sampling on EVOP.
 Joint software release.

--- a/_projects/fpga_project.md
+++ b/_projects/fpga_project.md
@@ -43,15 +43,6 @@ The team is submitting a proposal to DOE on this topic.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person cappello_f %} | 1 PM |
-| {% person finkel_h %} | 0.5 PM |
-| {% person yoshii_k %} | 0.5 PM |
-| {% person alvarez_c %} | 0.2 PM |
-
-
 ## Future plans
 
 Building on the results, we plan to hold FPGA workshops every six months. The next workshop will be hosted at UIUC on October 10-11, 2016. We will leverage these workshops to share the progress of our project, get feedback, and extend collaborations to other leading research groups.

--- a/_projects/ft_workflow_project.md
+++ b/_projects/ft_workflow_project.md
@@ -150,35 +150,6 @@ Remember to use the `--file jlesc.bib` with the `cite` tag.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person benoit_a %} | 1.0 PM |
-| {% person cappello_f %} | 1.0 PM |
-| {% person robert_y %} | 1.0 PM |
-| {% person cavelan_a %} | 3.0 PM |
-
-
-{% comment %}
-=========================================
-== ADD A TABLE OF PERSON-MONTH EFFORTS ==
-
-Put it in the following form, each person on its own line
-
-| {% person PERSON_ID %} | X.Y PM |
-
-e.g.:
-
-| {% person kabadshow_i %} | 2.0 PM |
-
-Above the very first person put the following line:
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-
-==================================
-== START HERE ==
-{% endcomment %}
-
 ## Future plans
 
 We have several results for replication with a single task. Our plan is now to 

--- a/_projects/ichpc_project.md
+++ b/_projects/ichpc_project.md
@@ -67,16 +67,6 @@ at SC’14 {% cite DorierEtAl2014b --file jlesc.bib %}.
 
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person antoniu_g %}    | 1 PM |
-| {% person ibrahim_s %} | 2 PM |
-| {% person dorier_m %}   | 1 PM   |
-| {% person yildiz_o %} | 10 PM |
-| {% person ross_r %}   | 1 PM   |
-
 ## Future plans
 
 ### Sub-goal 1:

--- a/_projects/interf_aware_sched.md
+++ b/_projects/interf_aware_sched.md
@@ -35,16 +35,6 @@ Internship of Orcun Yildiz at ANL from June to September 2015.
 
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person yildiz_o %} | 4 PM |
-| {% person dorier_m %} | 4 PM |
-| {% person ross_r %} | 1 PM |
-| {% person antoniu_g %} | 1 PM |
-| {% person ibrahim_s %} | 3 PM |
-
 ## Future plans
 
 We plan to further investigate the interference issue in the context of read workloads and mixed read/write workloads, as a way to extend our IPDPS 2016 paper.

--- a/_projects/mcfd_cmp_project.md
+++ b/_projects/mcfd_cmp_project.md
@@ -52,15 +52,6 @@ No publications yet.
 
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person lintermann_a %} | 0.5 PM |
-| {% person tsubokura_m %} | 0.5 PM |
-| {% person onishi_k %} | 1.0 PM |
-
-
 ## Future plans
 
 After accounts have been created on both machines, both groups will start to port their own codes to the according machines.

--- a/_projects/omniscio.md
+++ b/_projects/omniscio.md
@@ -35,14 +35,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person dorier_m %} | 2 PM |
-| {% person ross_r %} | 1 PM |
-| {% person antoniu_g %} | 1 PM |
-| {% person ibrahim_s %} | 1 PM |
-
 ## Future plans
 
 We plan to leverage Omnisc'IO first in the context of scheduling of I/O requests.

--- a/_projects/ompss_argobots_project.md
+++ b/_projects/ompss_argobots_project.md
@@ -105,18 +105,6 @@ This project will have the future impact and contributions as follows:
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person balaji_p %}  | 0.5 PM |
-| {% person seo_s %}     | 1.0 PM |
-| {% person amer_a %}    | 1.0 PM |
-| {% person badia_r %}   | 0.5 PM |
-| {% person labarta_j %} | 0.5 PM |
-| {% person teruel_x %}  | 1.5 PM |
-| {% person beltran_v %} | 0.5 PM |
-
-
 ## Future plans
 
 Next steps in this project are to have a more complete implementation of

--- a/_projects/ompss_mpi_project.md
+++ b/_projects/ompss_mpi_project.md
@@ -49,12 +49,6 @@ A paper {% cite MartsinkevichEtAl2015 --file jlesc.bib %} has been published in 
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person martsinkevich_t %} | 5.0 PM |
-| {% person subasi_o %} | 2.0 PM |
-
 ## Future plans
 
 There will be a journal submission based on this work.

--- a/_projects/pampa_project.md
+++ b/_projects/pampa_project.md
@@ -53,17 +53,6 @@ Therefore all these efforts will enable to further use Pampa to perform mesh ada
 * Mesh adaptivity
 
 
-## Person-Month efforts in 2015/2016
-
-The efforts of the participants so far are as follows:
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person houzeaux_g %}   | 3.0 PM |
-| {% person vazquez_m %}    | 2.0 PM |
-| {% person mehta_v %}      | 3.0 PM |
-| {% person jeannot_e %}    | 0.5 PM |
-
-
 ## Future plans
 
 * Implementation

--- a/_projects/pmefr_project.md
+++ b/_projects/pmefr_project.md
@@ -58,14 +58,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person amer_a %}    | 0.5 PM |
-| {% person balaji_p %}    | 1 PM |
-| {% person beltran_v %} | 1 PM |
-| {% person casas_m %}   | 1 PM   |
-
 ## Future plans
 
 We plan to push further the investigation of fine-grained fault-tolerance support in hybrid MPI+threads programming models.

--- a/_projects/reducing_communication_sparse.md
+++ b/_projects/reducing_communication_sparse.md
@@ -72,13 +72,6 @@ None yet.
 
 {% bibliography --cited --file jlesc.bib %}
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person bienz_a %}    | 0.1 PM |
-| {% person olson_l %}    | 0.1 PM |
-| {% person grigori_l %}  | 0.1 PM |
-| {% person gropp_b %}    | 0.1 PM |
 
 ## Future plans
 

--- a/_projects/sc16_project.md
+++ b/_projects/sc16_project.md
@@ -52,21 +52,6 @@ A 2 page white paper has been submitted to the BDEC workshop.
 
 {% bibliography --cited --file jlesc.bib %}
 
-
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person cappello_f %} | 1 PM |
-| {% person heitmann_k %} | 0.2 PM |
-| {% person allen_g %} | 0.1 PM |
-| {% person kettimuthu_r %} | 0.2 PM |
-| {% person sisneros_r %} | 0.2 PM |
-| {% person stevens_s %} | 0.1 PM |
-| {% person turk_m %} | 0.1 PM |
-| {% person wheeler_d %} | 0.2 PM |
-| {% person wilde_m %} | 0.1 PM |
-| {% person wozniak_j %} | 0.2 PM |
-
 ## Future plans
 See "Results" section.
 

--- a/_projects/scheduling_hpc_workflows.md
+++ b/_projects/scheduling_hpc_workflows.md
@@ -36,15 +36,6 @@ This project effectively started in 2016.
 
 {% bibliography --cited --file jlesc.bib %}
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person cheriere_n %} | 6 PM |
-| {% person dorier_m %}   | 2 PM |
-| {% person ross_r %}     | 1 PM |
-| {% person ibrahim_s %}  | 2 PM |
-| {% person antoniu_g %}  | 1 PM |
-
 
 ## Future plans
 

--- a/_projects/sdc_detection.md
+++ b/_projects/sdc_detection.md
@@ -65,19 +65,6 @@ None
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person bautista_gomez_l %} | 2.5 PM |
-| {% person benoit_a %} | 2 PM |
-| {% person cappello_f %} | 1 PM |
-| {% person cavelan_a %} | 3 PM |
-| {% person robert_y %} | 1.5 PM |
-| {% person subasi_o %} | 3 PM |
-| {% person sun_h %} | 3 PM |
-| {% person unsal_o %} | 1 PM |
-| {% person di_s %} | 1 PM |
-
 
 ## Future plans
 

--- a/_projects/shared_infra_ad.md
+++ b/_projects/shared_infra_ad.md
@@ -61,34 +61,6 @@ Remember to use the `--file jlesc.bib` with the `cite` tag.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person hovland_p %} | 0.5 PM |
-| {% person narayanan_s %} | 1.0 PM |
-| {% person hascoet_l %} | 1.0 PM |
-
-{% comment %}
-=========================================
-== ADD A TABLE OF PERSON-MONTH EFFORTS ==
-
-Put it in the following form, each person on its own line
-
-| {% person PERSON_ID %} | X.Y PM |
-
-e.g.:
-
-| {% person kabadshow_i %} | 2.0 PM |
-
-Above the very first person put the following line:
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-
-==================================
-== START HERE ==
-{% endcomment %}
-
-
 ## Future plans
 We plan to continue to integrate Tapenade and OpenAD infrastructures. Additionally, we plan to explore other
 topics in the field of algorithmic differentiation.

--- a/_projects/smart_in_situ.md
+++ b/_projects/smart_in_situ.md
@@ -39,18 +39,6 @@ None
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person peterka_t %} | 1.5 PM |
-| {% person ross_r %} | 1 PM |
-| {% person antoniu_g %} | 1.5 PM |
-| {% person dorier_m %} | 3 PM |
-| {% person sisneros_r %} | 1.5 PM |
-| {% person bautista_gomez_l %} | 1.5 PM |
-| {% person rahmani_l %} | 3 PM |
-| {% person bouge_l %} | 1.5 PM |
-
 ## Future plans
 
 Our short term plan is to extend our submitted Cluster paper into a journal paper including more experiments and more use cases.

--- a/_projects/tool_pandt_project.md
+++ b/_projects/tool_pandt_project.md
@@ -64,16 +64,6 @@ None yet.
 {% bibliography --cited --file jlesc.bib %}
 
 
-## Person-Month efforts in 2015/2016
-
-{:.person-months-table.table.table-bordered.table-hover.table-sm}
-| {% person feld_c %} | 1.0 PM |
-| {% person gimenez_j %} | 1.0 PM |
-| {% person murai_h %} | 1.0 PM |
-| {% person tsuji_m %} | 1.0 PM |
-| {% person wylie_b %} | 1.0 PM |
-
-
 ## Future plans
 
 The existing integration of XcalableMP and Scalasca will be updated to the latest


### PR DESCRIPTION
This removes all PM-related data from the website as requested by @Franckcappello. The release 1.0 still contains them for the report generation. For further reporting, we will separate this information from the project descriptions.

Signed-off-by: Robert Speck r.speck@fz-juelich.de
