### PR TITLE
Add Swann Perarnau @ ANL to people

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -977,6 +977,15 @@ pena_a:
   email:  antonio.pena@bsc.es
   homepage: https://www.bsc.es/es/about-bsc/staff-directory/pena-antonio
 
+perarnau_s:
+  sur_name: Perarnau
+  given_name: Swann
+  affiliation: anl
+  position: permanent
+  topics: Memory, Performance Tools, OS
+  email: swann@anl.gov
+  homepage: http://www.mcs.anl.gov/~perarnau/
+
 perez_c:
   sur_name: Perez
   given_name: Christian


### PR DESCRIPTION
Swann Perarnau will be appointed as permanent staff at Argonne National Lab in
September, and would like to participate in future JLESC activities.
