### PR TITLE
fixed typo (kentaro -> Kentaro), and adjusted keywords

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -1761,7 +1761,7 @@ sankaranarayanan_s:
 
 sano_k:
   sur_name: Sano
-  given_name: kentaro
+  given_name: Kentaro
   affiliation: riken
   position:
   topics: FPGAs

--- a/_projects/fpga_project.md
+++ b/_projects/fpga_project.md
@@ -13,8 +13,8 @@ keywords:
   - FPGA
   - High-level synthesis (OpenCL, OpenMP, OpenACC)
   - HPC kernel porting
-  - Manual and automatic optimizations
-  - Heterogeneous reconfigurable computing
+  - Manual and automatic optimization
+  - Reconfigurable computing
   - Dataflow computing
 head: yoshii_k
 members: 


### PR DESCRIPTION
Signed-off-by: Kazutomo Yoshii <kazutomo.yoshii@gmail.com>