### PR TITLE
Add Romain Pereira to runtime interop project

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -2425,6 +2425,15 @@ perarnau_s:
   email: swann@anl.gov
   homepage: http://www.mcs.anl.gov/~perarnau/
 
+pereira_r:
+  sur_name: Pereira
+  given_name: Romain
+  affiliation: anl
+  position:
+  topics:
+  email: rpereira@anl.gov
+  homepage:
+
 perez_c:
   sur_name: Perez
   given_name: Christian
@@ -3631,6 +3640,5 @@ dutot_p:
   email:
   homepage:
   
-
 
 

--- a/collections/_projects/runtime_interop.md
+++ b/collections/_projects/runtime_interop.md
@@ -2,7 +2,7 @@
 layout: post
 title: Enhancing Interoperability in Task-based Programming Models through Common Low-Level Interfaces
 date: 2024-09-11
-updated: 2026-01-21
+updated: 2026-03-23
 navbar: Research
 subnavbar: Projects
 project_url:
@@ -27,6 +27,7 @@ members:
   - maya_t
   - rao_r
   - schuchart_j
+  - pereira_r
 ---
 
 ## Research topic and goals


### PR DESCRIPTION
## Summary
- add Romain Pereira to the runtime interoperability project member list
- add the corresponding `pereira_r` person entry with ANL affiliation and email
- refresh the project's `updated` date